### PR TITLE
Ignore the port when checking for matching domain

### DIFF
--- a/enforce_host/__init__.py
+++ b/enforce_host/__init__.py
@@ -3,6 +3,7 @@ __version__ = '1.0.1'
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponsePermanentRedirect
+from django.http.request import split_domain_port
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
@@ -10,9 +11,9 @@ except ImportError:
 
 
 try:
-  string_type = basestring
+    string_type = basestring
 except NameError:
-  string_type = str
+    string_type = str
 
 
 class EnforceHostMiddleware(MiddlewareMixin):
@@ -31,6 +32,7 @@ class EnforceHostMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         host = request.get_host()
+        host, port = split_domain_port(host)
 
         if host in self.allowed_hosts:
             return

--- a/enforce_host/tests/tests.py
+++ b/enforce_host/tests/tests.py
@@ -9,6 +9,11 @@ class EnforceHostTestCase(TestCase):
         response = self.client.get('/', HTTP_HOST='enforced.com')
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(ENFORCE_HOST='enforced.com')
+    def test_host_with_port_allowed(self):
+        response = self.client.get('/', HTTP_HOST='enforced.com:8080')
+        self.assertEqual(response.status_code, 200)
+
     @override_settings(ENFORCE_HOST=['enforced.com', 'enforced2.com'])
     def test_multiple_hosts_allowed(self):
         response = self.client.get('/', HTTP_HOST='enforced2.com')


### PR DESCRIPTION
This is what Django's built-in host checking does for ALLOWED_HOSTS.

Thanks!