### PR TITLE
Put SecurityMiddleware first

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ Install from PIP
 
     pip install django-enforce-host
 
-In your `MIDDLEWARE` setting, add the following at the top:
+In your `MIDDLEWARE` setting, add the middleware just after the `SecurityMiddleware`:
 
     MIDDLEWARE = [
+        # Django's SecurityMiddleware will handle HTTP -> HTTPS redirects
+        # before the EnforceHostMiddleware redirects to the canonical domain
+        'django.middleware.security.SecurityMiddleware',
         'enforce_host.EnforceHostMiddleware',
         ... other middleware
     ]


### PR DESCRIPTION
Recommend putting Django's `SecurityMiddleware` first. This middleware will handle HTTP -> HTTPS redirects and other important redirects before enforcing the host. Specifically [Mozilla's recommendations](https://infosec.mozilla.org/guidelines/web_security#http-redirections) recommend redirecting all HTTP resources to HTTPS before changing domains. This ensures that Strict Transport Security settings are applied to the user's browser.

Fixes https://github.com/dabapps/django-enforce-host/issues/3