### PR TITLE
Add Django 4.1 to test matrix, remove Django 2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,16 @@ jobs:
     strategy:
       matrix:
         python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        django: ["2.2", "3.2", "4.0"]
+        django: ["3.2", "4.0", "4.1"]
         exclude:
           - python: "3.6"
             django: "4.0"
+          - python: "3.6"
+            django: "4.1"
           - python: "3.7"
             django: "4.0"
-          - python: "3.10"
-            django: "2.2"
+          - python: "3.7"
+            django: "4.1"
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sometimes, it's unavoidable that multiple URLs point at the same app - for examp
 
 This is a simple Django middleware that redirects all traffic from hosts other than the one(s) you specify to your canonical URL.
 
-Tested against Django 2.2, 3.2 and 4.0 on Python 3.6, 3.7, 3.8, 3.9 and 3.10
+Tested against Django 3.2 and 4.0 and 4.1 on Python 3.6, 3.7, 3.8, 3.9 and 3.10
 
 ### Installation
 

--- a/enforce_host/__init__.py
+++ b/enforce_host/__init__.py
@@ -4,36 +4,26 @@ from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponsePermanentRedirect
 
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = object
 
-
-try:
-    string_type = basestring
-except NameError:
-    string_type = str
-
-
-class EnforceHostMiddleware(MiddlewareMixin):
-    def __init__(self, get_response=None):
+class EnforceHostMiddleware:
+    def __init__(self, get_response):
         self.get_response = get_response
+
         setting_value = getattr(settings, "ENFORCE_HOST", None)
 
         if setting_value is None:
             raise MiddlewareNotUsed()
 
-        if isinstance(setting_value, string_type):
+        if isinstance(setting_value, str):
             setting_value = [setting_value]
 
         self.allowed_hosts = setting_value
 
-    def process_request(self, request):
+    def __call__(self, request):
         host = request.get_host()
 
         if host in self.allowed_hosts:
-            return
+            return self.get_response(request)
 
         new_url = "%s://%s%s" % (
             "https" if request.is_secure() else "http",


### PR DESCRIPTION
~Hopefully this will fail and then we can look at fixing #8~

Fixes #8 

I've converted the middleware to "new style" rather than using the `MiddlewareMixin` deprecation shim (old-style middleware was deprecated in Django 1.1). I've also removed a bit of Python 2 (!) compatibility code.